### PR TITLE
1.5 Terrain Affordance update

### DIFF
--- a/1.5/Defs/ThingDefs_Buildings/Dubs_Skylight.xml
+++ b/1.5/Defs/ThingDefs_Buildings/Dubs_Skylight.xml
@@ -68,7 +68,7 @@
 		<category>Building</category>
 		<soundImpactDefault>BulletImpact_Metal</soundImpactDefault>
 		<drawerType>MapMeshAndRealTime</drawerType>
-		<terrainAffordanceNeeded>Light</terrainAffordanceNeeded>
+		<terrainAffordanceNeeded IsNull="True" />
 		<repairEffect>Repair</repairEffect>
 		<filthLeaving>Filth_RubbleBuilding</filthLeaving>
 		<tickerType>Rare</tickerType>


### PR DESCRIPTION
Skylights now have a null terrain affordance, so bridges don't need to be built under them.